### PR TITLE
fix(threads): Header Is Hidden When Download Preview is Open

### DIFF
--- a/src/Threads/index.tsx
+++ b/src/Threads/index.tsx
@@ -54,7 +54,7 @@ export default function Threads() {
         <BackButton />
         <Social />
       </header>
-      <main className='flex items-center w-full flex-col justify-center gap-4 h-[95%] overflow-scroll bg-white-400 bg-clip-padding backdrop-filter backdrop-blur-3xl bg-opacity-10  pb-10'>
+      <main className='flex items-center w-full flex-col justify-center gap-4 h-[95%] overflow-scroll bg-white-400 bg-clip-padding backdrop-filter backdrop-blur-3xl bg-opacity-10  pb-10 pt-40'>
         <span className='flex flex-col items-center'>
           <h1 className='md:text-flg text-fmd font-bold text-center'>
             Convert Your Threads Post To Images


### PR DESCRIPTION
fix #75

# Fixes Issue

**My PR closes #75**

# 👨‍💻 Changes proposed(What did you do ?)
- added a padding between the header and the main container

# ✔️ Check List (Check all the applicable boxes)

- [] My code follows the code style of this project.
- [] This PR does not contain plagiarized content.
- [] The title and description of the PR is clear and explains the approach.

##  Note to reviewers
The reason why i got that bug was because my browser was zoomed to 110%. I figured that out while looking for a solution, if there are users like me who love to zoom a web page to see the contents properly, they wouldn't have that issue anymore.

The screenshot below shows how it looks when the page is zoomed to 110%.

# 📷 Screenshots

![Screenshot (7)](https://github.com/Dun-sin/Threstagram/assets/24679488/218a7059-824c-4a48-92b6-959061ce2f7d)
